### PR TITLE
Roadmap and Blog updates

### DIFF
--- a/_posts/2024-07-21-cp-roadmap.html
+++ b/_posts/2024-07-21-cp-roadmap.html
@@ -7949,8 +7949,9 @@ h1.main{
                 title="DP-on-Grids-"><span
                     class="octicon octicon-link ph ph-link-simple-horizontal"></span></a><strong><span>DP on Grids
                     :</span></strong></h3>
-        <p><a href="https://atcoder.jp/contests/dp/tasks/" target="_blank" rel="noopener"><span>This tutorial
-                </span></a><span>has some generic problems which will develop your understanding about grids .</span>
+        <p><span>Read </span><a href="https://usaco.guide/CPH.pdf#page=81" target="_blank"
+                    rel="noopener"><span> CPH CH7-3 </span></a><span> and </span><a
+                    href="https://usaco.guide/CPH.pdf#page=84" target="_blank" rel="noopener"><span> CPH CH7-5 </span></a><span> . It will develop your understanding about DP on Grids. </span>
         </p>
         <blockquote>
             <ul class="contains-task-list">
@@ -9634,6 +9635,8 @@ h1.main{
             <li><mark><a href="https://youkn0wwho.academy/topic-list" target="_blank" rel="noopener"><span>The Ultimate
                             Topic List</span></a></mark></li>
             <li><a href="https://cses.fi/problemset/" target="_blank" rel="noopener"><span>CSES Problem Set</span></a>
+            </li>
+            <li><a href="https://www.interviewbit.com/courses/programming/" target="_blank" rel="noopener"><span>InterviewBit </span></a>
             </li>
             <li><a href="https://earthshakira.github.io/a2oj-clientside/server/Ladders.html" target="_blank"
                     rel="noopener"><span>A2OJ Ladders</span></a></li>

--- a/_posts/2025-01-08-GNU-PBDS.md
+++ b/_posts/2025-01-08-GNU-PBDS.md
@@ -227,7 +227,7 @@ Each of these implementations comes with its own perks and specific use cases, o
 using namespace __gnu_pbds;
 
 // replace thin_heap with the <tag> of your choice
-typename __gnu_pbds::priority_queue<int, less<int>, thin_heap_tag> myPQ;
+typedef priority_queue<int, less<int>, thin_heap_tag> myPQ;
 ```
 
 #### Methods
@@ -375,7 +375,7 @@ int main() {
 ## pb_ds in Action
 
 #### 1) Count Number of Inversions in an Array
-Using `ordered_set`
+Using `ordered_set`. Note the use of `less_equal<int>` comparator, essentially making it an `ordered_multiset`.
 ```cpp
 #include <bits/stdc++.h>
 using namespace std;
@@ -384,7 +384,7 @@ using namespace std;
 #include <ext/pb_ds/tree_policy.hpp>
 using namespace __gnu_pbds;
 
-typedef tree<int, null_type, less<int>, rb_tree_tag, tree_order_statistics_node_update> ordered_set;
+typedef tree<int, null_type, less_equal<int>, rb_tree_tag, tree_order_statistics_node_update> ordered_set;
 
 int countInversions(vector<int>& arr) {
     ordered_set os;
@@ -535,6 +535,8 @@ These are some more [examples](https://github.com/gcc-mirror/gcc/tree/master/lib
 ### Conclusion
 pb\_ds is a treasure trove for competitive programmers. It saves time, simplifies code, and enables you to focus on solving problems rather than debugging custom data structures. With its variety of priority queue implementations, tree-based containers, hash-based structures and many more, it’s a must-have tool in your arsenal.
 Thank you!
+
+_Authors: Tattwa Shiwani, Khushi Ranawat
 
 ### References :
 


### PR DESCRIPTION
## Summary by Sourcery

Update GNU-PBDS and CP roadmap blog posts with improved code examples, authorship, and resource links.

Documentation:
- Refactor priority_queue alias in GNU-PBDS post to use typedef for consistency
- Clarify ordered_set example by switching comparator to less_equal and noting its multiset behavior
- Add authorship attribution to the GNU-PBDS blog post
- Update DP-on-Grids section in CP roadmap to reference specific CPH PDF chapters instead of generic AtCoder tutorial
- Add InterviewBit resource to the CP roadmap's Additional Topics list