### PR TITLE
Added max width for logo

### DIFF
--- a/_sass/3-modules/_header.scss
+++ b/_sass/3-modules/_header.scss
@@ -42,6 +42,7 @@
 
 .logo__image {
   max-height: 40px;
+  max-width: 40px;
 }
 
 /* Nav */


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Add max-width of 40px to the logo image to match its max-height constraint.